### PR TITLE
Modify metadata.ini to allow QGIS 3 users to load collections

### DIFF
--- a/metadata.ini
+++ b/metadata.ini
@@ -8,9 +8,8 @@ name=Mapbox's Maki Icons
 tags=maki, icon, svg, mapbox
 description=Maki is an icon set made for map designers created by Mapbox
 qgis_minimum_version=2.0
-qgis_maximum_version=2.99
+qgis_maximum_version=3.98
 preview=preview/maki.png
-
 [osm_spatialite_googlemaps]
 author=Anita Graser
 email=anitagraser@gmx.at
@@ -19,8 +18,7 @@ tags=osm, spatialite, google maps, roads
 description=The collection contains a complete resources to create a coherent map that looks similar to the old Google Maps style from OSM data in a SpatiaLite database (created using ogr2ogr default settings)
 preview=preview/osm_spatialite_googlemaps.png, preview/osm_spatialite_googlemaps_lines.qml.png
 qgis_minimum_version=2.0
-qgis_maximum_version=2.99
-
+qgis_maximum_version=3.90
 [z_m_styling]
 author=Régis Haubourg
 email=regis.haubourg@oslandia.com
@@ -28,9 +26,8 @@ name=Z altitudes styling for 3DM geometries
 tags=z, altitude, vertices
 description=The collection offers some styles to render z or M values of geometries in QGIS.
 qgis_minimum_version=2.16
-qgis_maximum_version=2.99
+qgis_maximum_version=3.98
 preview=preview/z_styling.png
-
 [gis_lab]
 author=Yury Ryabov and Pavel Sergeev
 email=riabovvv@gmail.com
@@ -41,8 +38,7 @@ preview=preview/preview.png, preview/svgs.png
 license=This collection is released under CC-BY 3.0 unported license
 license_file=LICENSE.txt
 qgis_minimum_version=2.0
-qgis_maximum_version=2.99
-
+qgis_maximum_version=3.98
 [road_signs]
 author=Bertrand Bouteilles
 email=sig974@free.fr
@@ -51,13 +47,12 @@ tags=svg, icon, roads
 description=This collection contains road sign SVGs for the following categories: priority, warning, prohibity, mandatory, regulation, indication
 preview=preview/preview.png
 qgis_minimum_version=2.0
-qgis_maximum_version=2.99
-
+qgis_maximum_version=3.98
 [rscripts]
 author=QGIS Contributors
 email=havard.tveite@nmbu.no
 name=QGIS R script collection
 tags=R,script,processing,provider
 description=The QGIS 2 on-line R script collection. Can be used with the Processing R provider plugin in QGIS from version 3.4.
-qgis_minimum_version=2.99
+qgis_minimum_version=2.00
 qgis_maximum_version=3.98


### PR DESCRIPTION
Due to an issue with the *Resource Sharing* plugin, collections that are listed after a "not compatible" collection will be ignored: https://github.com/akbargumbira/qgis_resources_sharing/issues/60 .
This means that QGIS 3 users will not be able to use any of the collections in the QGIS Resources repository through the *Resource Sharing* plugin!
The *Resource Sharing* plugin issue should of course be fixed, but I have found out that the collections in the QGIS Resources repository that are tagged with a max version of 2.99 also work fine with QGIS 3, so we don't have to wait for the plugin fix (an easy one, that I have proposed in https://github.com/akbargumbira/qgis_resources_sharing/pull/61, that just got merged) to make it to a published version.

This PR changes the max version from 2.99 to 3.98 for the SVG collections (they work fine in QGIS 3), and from 2.99 to 3.9 for the other collections (have not tested if they can be used for anything, but they do not seem to cause any trouble).