### PR TITLE
Remove Atilio from default repositories

### DIFF
--- a/directory.csv
+++ b/directory.csv
@@ -1,6 +1,5 @@
 QGIS Official Repository,https://github.com/qgis/QGIS-Resources.git
 Anita's Repository,https://github.com/anitagraser/QGIS-resource-collections.git
-Atilio's Repository,http://www.nasca.ovh/downloads/nautical/
 Dale Kunce's Repository at the American Red Cross,https://github.com/AmericanRedCross/redcross_qgis_styles.git
 Faunalia,https://github.com/faunalia/QGIS-Resources.git
 PlanZV Repository,https://github.com/bstroebl/PlanZV.git


### PR DESCRIPTION
Hi,

Resource Sharing plugin developer here ;)

Since http://www.nasca.ovh/downloads/nautical/ is not reachable anymore, I propose to remove it. It makes the plugin tests fail...

Furthermore, I suggest not to integrate any more repositories that are not hosted on HTTPS or on a code sharing platform (GitHub, GitLab, giteo, bitbucket...) whose availability level is relatively reliable.

Also, I'm working on making the plugin more robust so that a problem in the default repositories won't make it crash. Or even to make this download optional (opt-in) and manual after the plugin is installed by the end user.

