### PR TITLE
add repo for GRASS's geologic symbols

### DIFF
--- a/directory.csv
+++ b/directory.csv
@@ -23,3 +23,4 @@ Juhele Map Icons,https://github.com/juhele/Juhele-map-icons.git
 Ludovico's Repository,https://github.com/ludovico85/QGIS-resources-sharing.git
 Star-Eau french symbols,https://gitlab.com/star-eau/symbologie.git
 Alfobre Repository,https://github.com/projetoalfobre/alfobre-qgis-resources.git
+Geologic Symbols (GRASS),https://github.com/HamishB/geology_symbols.git


### PR DESCRIPTION
Hi, for your consideration here's a PR that adds a simple collection of SVG symbols for geologic mapping. I've ported these over from the symbols I created for GRASS some time ago.
I've written the SVG files to support QGIS's stroke+fill color, line width, and opacity settings.

I plan to add some line (geologic contact) styles into the repo in the next couple months.

It's unclear to me if the newest listings in directory.csv should simply be added to the end of the list, put in alphabetical order, or grouped with like kinds (e.g. next to the existing USGS Geologic symbol repo).  Maybe this all gets alphabetized in the GUI so it doesn't matter.


bug which makes it difficult for me to test:
    https://github.com/QGIS-Contribution/QGIS-ResourceSharing/discussions/363

wish to encourage an end-to-end fully FOSS toolchain:
(support git.osgeo.org or codeberg.org git repos too)
    https://github.com/QGIS-Contribution/QGIS-ResourceSharing/issues/360


.
many thanks & greets from FOSS4G 2025.